### PR TITLE
Handle new args order for cli pegjs 0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license" : "MIT",
   "main": "index.js",
   "scripts": {
-    "prepublish": "pegjs grammar.peg parser.js"
+    "prepublish": "pegjs -o parser.js grammar.peg"
   },
   "repository": {
     "type": "git",
@@ -13,7 +13,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "pegjs": ">=0.7 <1"
+    "pegjs": ">=0.10 <1"
   },
   "readmeFilename": "README.md",
   "keywords": [


### PR DESCRIPTION
Latest release for pegjs 0.10.0 on 2016/08/19 now requires the
output file be identified by using the `-o` option.  As mentioned
in #12 the `npm install` would fail building `parser.js`.

This change updates the `package.json` `prepublish` command to use
`-o`.  The required version for pegjs is updated to ">=0.10".

Resolves #12