### PR TITLE
Handle two elliptical arc implementation note details

### DIFF
--- a/grammar.peg
+++ b/grammar.peg
@@ -140,9 +140,13 @@ elliptical_arc_argument_sequence
   { return merge(first,more) }
 
 elliptical_arc_argument
-  = rx:nonnegative_number comma_wsp? ry:nonnegative_number comma_wsp?
-        xrot:number comma_wsp large:flag comma_wsp? sweep:flag comma_wsp? xy:coordinate_pair
-  { return { rx:rx, ry:ry, xAxisRotation:xrot, largeArc:large, sweep:sweep, x:xy.x, y:xy.y } }
+  = rx:number comma_wsp? ry:number comma_wsp?
+        xrot:number comma_wsp large:number comma_wsp? sweep:number comma_wsp? xy:coordinate_pair
+  { return { rx:Math.abs(rx), ry:Math.abs(ry),
+             xAxisRotation:xrot,
+             largeArc:!!large?1:0,
+             sweep:!!sweep?1:0,
+             x:xy.x, y:xy.y } }
 
 
 coordinate_pair
@@ -156,10 +160,6 @@ nonnegative_number
 number
   = parts:(sign? floating_point_constant / sign? digit_sequence)
   { return parts.join('')*1 }
-
-flag
-  = bit:[01]
-  { return bit=='1' }
 
 comma_wsp
   = (wsp+ comma? wsp*) / (comma wsp*)


### PR DESCRIPTION
As mentioned in issue #13 `grammar.peg` is a completely literal implementation of the SVG 1.1 grammar found in [8.3.9 The grammar for path data](https://www.w3.org/TR/SVG/paths.html#PathDataBNF).  However the SVG spec's grammar does not reflect the appendix F.5 and F.6 implementation notes for path strings, so a strictly derived grammar does not match the complete SVG implementation requirements.

This change covers two of the details mentioned in appendix [F.6 Elliptical arc implementation notes](https://www.w3.org/TR/SVG/implnote.html#ArcImplementationNotes) in the subsection [F.6.2 Out-of-range parameters](https://www.w3.org/TR/SVG/implnote.html#ArcOutOfRangeParameters).

The rx/ry arguments grammar is changed to `number` from `nonnegative_number` and then the rule's inline code converts to the absolute value, to conform to the implementation notes.

The two 'flag' arguments are changed to `number` from `flag`, and then the rule's inline code forces nonzero values to 1.  As this was the only use of the rule `flag` that rule is deleted from the grammar.